### PR TITLE
Default Server Option + Interaction Reply Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 
 - `/status [server|ip]` - Displays the current status and active players for any server
 - `/monitor ip [nickname]` - Create 2 voice channels that display the status of a Minecraft server and optionally set a nickname
-- `/nickname [server] nickname` - Change the nickname of a monitored Minecraft server
-- `/default [server]` - Set a server to be the default for all commands
+- `/nickname nickname [server]` - Change the nickname of a monitored Minecraft server
+- `/default server` - Set a server to be the default for all commands
 - `/unmonitor [server|all]` - Unmonitor the specified server or all servers
 - `/bug description` - Send a bug report to the maintainers
 - `/help` - List the other commands

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 
 ## Now Updated!!
 
-- Updated Jan 2023
+- Updated Feb 2023
+- Default server option has been implemented! Set a monitored server to be the default for all commands so that you don't have to constantly type in the nickname or IP address
 - Nicknames have been implemented! Set a nickname for your server with the `/nickname` command. You can refer to the server using its nickname in all commands!
 
 ## Features
@@ -27,6 +28,7 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 - `/status [server|ip]` - Displays the current status and active players for any server
 - `/monitor ip [nickname]` - Create 2 voice channels that display the status of a Minecraft server and optionally set a nickname
 - `/nickname [server] nickname` - Change the nickname of a monitored Minecraft server
+- `/default [server]` - Set a server to be the default for all commands
 - `/unmonitor [server|all]` - Unmonitor the specified server or all servers
 - `/bug description` - Send a bug report to the maintainers
 - `/help` - List the other commands
@@ -45,3 +47,4 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 - [ ] Fix DDNS support issues
 - [x] Add bug reporting command
 - [ ] Support compatibility with bedrock servers
+- [ ] IP validation

--- a/commands/bug.js
+++ b/commands/bug.js
@@ -7,16 +7,9 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('bug')
 		.setDescription('Send a bug report to maintainers')
-		.addStringOption((option) => option.setName('bug').setDescription('Description of the bug').setRequired(true)),
+		.addStringOption((option) => option.setName('description').setDescription('Description of the bug').setRequired(true)),
 	async execute(interaction) {
-		await interaction.deferReply({ ephemeral: true });
-
-		const bug = interaction.options.getString('bug');
-
-		if (!bug) {
-			await sendMessage.newBasicMessage(interaction, 'Please specify a bug that you would like to report.');
-			return;
-		}
+		const bug = interaction.options.getString('description');
 
 		if (profanity.exists(bug)) {
 			await sendMessage.newBasicMessage(interaction, 'Your query triggered our spam protection. Please try again, or open a github issue.');

--- a/commands/default.js
+++ b/commands/default.js
@@ -1,0 +1,48 @@
+const Discord = require('discord.js');
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const sendMessage = require('../functions/sendMessage');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('default')
+		.setDescription('Set a server to be the default for all commands')
+		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(true)),
+	async execute(interaction) {
+		// Check if the member has the administrator permission
+		if (!interaction.memberPermissions.has(Discord.PermissionsBitField.Flags.Administrator)) {
+			await sendMessage.newBasicMessage(interaction, 'You must have the administrator permission to use this command!');
+			return;
+		}
+
+        // Check if there are any servers to make the default for all commands
+		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
+		if (!monitoredServers.length) {
+			await sendMessage.newBasicMessage(interaction, 'There are no servers to make the default for all commands!');
+			return;
+		}
+		if (monitoredServers.length == 1) {
+			await sendMessage.newBasicMessage(interaction, 'You only have 1 monitored server and it is already the default for all commands!');
+			return;
+		}
+
+		// Find the server to make the default for all commands
+		let serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
+		serverIndex == -1 ? serverIndex = await monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;
+		let server = serverIndex != -1 ? monitoredServers[serverIndex] : null;
+
+		// Check if the server is being monitored
+		if (!server) {
+			await sendMessage.newBasicMessage(interaction, 'The server you have specified was not already being monitored!')
+			return;
+		}
+
+		// Change the default server for all commands
+		for (const server of monitoredServers) {
+			server.default = false;
+		}
+        server.default = true;
+        await serverDB.set(interaction.guildId, monitoredServers);
+
+		await sendMessage.newBasicMessage(interaction, 'The server has successfully been made the default for all commands.');
+	}
+};

--- a/commands/help.js
+++ b/commands/help.js
@@ -12,12 +12,16 @@ module.exports = {
 				value: 'Displays the current status and active players for any server'
 			},
 			{
-				name: '/monitor ip [nickname]',
+				name: '/monitor ip [nickname] [default (true/false)]',
 				value: 'Create 2 voice channels that display the status of a Minecraft server and optionally set a nickname'
 			},
 			{
 				name: '/nickname [server] nickname',
 				value: 'Change the nickname of a monitored Minecraft server'
+			},
+			{
+				name: '/default [server]',
+				value: 'Set a server to be the default for all commands'
 			},
 			{
 				name: '/unmonitor [server|all]',

--- a/commands/help.js
+++ b/commands/help.js
@@ -4,8 +4,6 @@ const Discord = require('discord.js');
 module.exports = {
 	data: new SlashCommandBuilder().setName('help').setDescription('List the other commands'),
 	async execute(interaction) {
-		await interaction.deferReply({ ephemeral: true });
-
 		const helpEmbed = new Discord.EmbedBuilder().setTitle('Commands:').setColor(embedColor).addFields(
 			{
 				name: '/status [server|ip]',
@@ -16,11 +14,11 @@ module.exports = {
 				value: 'Create 2 voice channels that display the status of a Minecraft server and optionally set a nickname'
 			},
 			{
-				name: '/nickname [server] nickname',
+				name: '/nickname nickname [server]',
 				value: 'Change the nickname of a monitored Minecraft server'
 			},
 			{
-				name: '/default [server]',
+				name: '/default server',
 				value: 'Set a server to be the default for all commands'
 			},
 			{

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -8,7 +8,8 @@ module.exports = {
 		.setName('monitor')
 		.setDescription('Create 2 voice channels that display the status of a Minecraft server')
 		.addStringOption((option) => option.setName('ip').setDescription('IP address').setRequired(true))
-		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(false)),
+		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(false))
+		.addBooleanOption((option) => option.setName('default').setDescription('Set this server to be the default for all commands').setRequired(false)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });
 
@@ -39,11 +40,21 @@ module.exports = {
 			return;
 		}
 
+		// Set the default server to the new server if specified
+		if (interaction.options.getString('default') && monitoredServers.length) {
+			for (const server of monitoredServers) {
+				server.default = false;
+			}
+			await serverDB.set(interaction.guildId, monitoredServers);
+		}
+
 		// Create the server object
 		let newServer = {
 			ip: interaction.options.getString('ip'),
-			nickname: interaction.options.getString('nickname') || null
+			nickname: interaction.options.getString('nickname') || null,
+			default: interaction.options.getString('default') || false
 		};
+		!monitoredServers.length ? newServer.default == true : null;
 
 		// Create the server category
 		await interaction.guild.channels

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -11,8 +11,6 @@ module.exports = {
 		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(false))
 		.addBooleanOption((option) => option.setName('default').setDescription('Set this server to be the default for all commands').setRequired(false)),
 	async execute(interaction) {
-		await interaction.deferReply({ ephemeral: true });
-
 		// Check if the member has the administrator permission
 		if (!interaction.memberPermissions.has(Discord.PermissionsBitField.Flags.Administrator)) {
 			await sendMessage.newBasicMessage(interaction, 'You must have the administrator permission to use this command!');
@@ -41,20 +39,19 @@ module.exports = {
 		}
 
 		// Set the default server to the new server if specified
-		if (interaction.options.getString('default') && monitoredServers.length) {
+		if (interaction.options.getBoolean('default') && monitoredServers.length) {
 			for (const server of monitoredServers) {
 				server.default = false;
 			}
-			await serverDB.set(interaction.guildId, monitoredServers);
 		}
 
 		// Create the server object
 		let newServer = {
 			ip: interaction.options.getString('ip'),
 			nickname: interaction.options.getString('nickname') || null,
-			default: interaction.options.getString('default') || false
+			default: interaction.options.getBoolean('default') || false
 		};
-		!monitoredServers.length ? newServer.default == true : null;
+		!monitoredServers.length ? newServer.default = true : null;
 
 		// Create the server category
 		await interaction.guild.channels
@@ -102,6 +99,6 @@ module.exports = {
 
 		await updateChannels.execute(newServer);
 
-		await sendMessage.newBasicMessage(interaction, 'The channels have been created successfully.');
+		await sendMessage.newBasicMessage(interaction, 'The channels have successfully been created.');
 	}
 };

--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -37,8 +37,11 @@ module.exports = {
 			return;
 		}
 
+		// Find the default server
+		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default);
+		let server = monitoredServers[defaultServerIndex];
+
 		// Find the server to rename
-		let server = monitoredServers.length == 1 ? monitoredServers[0] : null;
 		if (interaction.options.getString('server')) {
 			let serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
 			serverIndex == -1 ? serverIndex = await monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;

--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -6,11 +6,9 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('nickname')
 		.setDescription('Change the nickname of a monitored Minecraft server')
-		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(true))
-		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(true)),
+		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(true))
+		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
-		await interaction.deferReply({ ephemeral: true });
-
 		// Check if the member has the administrator permission
 		if (!interaction.memberPermissions.has(Discord.PermissionsBitField.Flags.Administrator)) {
 			await sendMessage.newBasicMessage(interaction, 'You must have the administrator permission to use this command!');
@@ -61,6 +59,6 @@ module.exports = {
         // Rename the server category
         await interaction.guild.channels.cache.get(server.categoryId).setName(interaction.options.getString('nickname'));
 
-		await sendMessage.newBasicMessage(interaction, 'The server has been renamed successfully.');
+		await sendMessage.newBasicMessage(interaction, 'The server has successfully been renamed.');
 	}
 };

--- a/commands/status.js
+++ b/commands/status.js
@@ -9,8 +9,6 @@ module.exports = {
 		.setDescription('Displays the current status and active players for any server')
 		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
-		await interaction.deferReply({ ephemeral: true });
-
 		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
 
 		// Find the default server

--- a/commands/status.js
+++ b/commands/status.js
@@ -12,8 +12,12 @@ module.exports = {
 		await interaction.deferReply({ ephemeral: true });
 
 		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
-		let serverIp = monitoredServers.length == 1 ? monitoredServers[0].ip : null;
-		if (interaction.options.getString('server')) {
+
+		// Find the default server
+		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default);
+		let serverIp = monitoredServers[defaultServerIndex].ip;
+
+		if(interaction.options.getString('server')) {
 			serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
 			serverIp = serverIndex == -1 ? interaction.options.getString('server') : monitoredServers[serverIndex].ip;
 		}

--- a/commands/unmonitor.js
+++ b/commands/unmonitor.js
@@ -9,8 +9,6 @@ module.exports = {
 		.setDescription('Unmonitor the specified server or all servers')
 		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
-		await interaction.deferReply({ ephemeral: true });
-
 		// Check if member has administrator permission
 		if (!interaction.memberPermissions.has(Discord.PermissionsBitField.Flags.Administrator)) {
 			await sendMessage.newBasicMessage(interaction, 'You must have the administrator permission to use this command!');

--- a/commands/unmonitor.js
+++ b/commands/unmonitor.js
@@ -39,8 +39,11 @@ module.exports = {
 			return;
 		}
 
+		// Find the default server
+		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default);
+		let server = monitoredServers[defaultServerIndex];
+
 		// Find the server to unmonitor
-		let server = monitoredServers.length == 1 ? monitoredServers[0] : null;
 		if (interaction.options.getString('server')) {
 			let serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
 			serverIndex == -1 ? serverIndex = await monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -9,25 +9,14 @@ module.exports = {
 		if (!command) return;
 
 		try {
+			await interaction.deferReply({ ephemeral: true });
 			await command.execute(interaction);
 		} catch (error) {
 			console.log(error.code);
-
-			try {
-				await interaction.reply({
-					content: 'There was an error while executing this command!',
-					ephemeral: true
-				});
-			} catch (err) {
-				console.log(`${err.code} occured while replying. Trying to edit existing reply`);
-
-				await interaction
-					.editReply({
-						content: 'There was an error while executing this command!',
-						ephemeral: true
-					})
-					.catch((e) => console.log(e.code));
-			}
+			await interaction.editReply({
+				content: 'There was an error while executing this command!',
+				ephemeral: true
+			});
 		}
 	}
 };


### PR DESCRIPTION
Added ability to specify a default server for all commands (/default and default option in /monitor)
Fixed bug where command failure would throw an error due to interaction.reply being used instead of interaction.editReply