### PR TITLE
Default Server Bug Fixes, Rate Limiting Handler

### DIFF
--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -73,7 +73,6 @@ module.exports = {
 			})
 			.then((channel) => {
 				newServer.categoryId = channel.id;
-				newServer.default ? channel.setName(channel.name + '*') : null;
 			});
 
 		// Create the channels and add to category

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -38,11 +38,13 @@ module.exports = {
 			return;
 		}
 
-		// Set the default server to the new server if specified
+		// Unset the default server if the new server is to be the default for all commands
 		if (interaction.options.getBoolean('default') && monitoredServers.length) {
-			for (const server of monitoredServers) {
-				server.default = false;
-			}
+			let defaultServerIndex = await monitoredServers.findIndex((server) => server.default) || 0;
+			let oldDefaultServer = monitoredServers[defaultServerIndex];
+			oldDefaultServer.default = false;
+			let oldDefaultCategory = await interaction.guild.channels.cache.get(oldDefaultServer.categoryId);
+			oldDefaultCategory.setName(oldDefaultCategory.name.slice(0,-1));
 		}
 
 		// Create the server object
@@ -71,6 +73,7 @@ module.exports = {
 			})
 			.then((channel) => {
 				newServer.categoryId = channel.id;
+				newServer.default ? channel.setName(channel.name + '*') : null;
 			});
 
 		// Create the channels and add to category

--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -36,7 +36,7 @@ module.exports = {
 		}
 
 		// Find the default server
-		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default);
+		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default) || 0;
 		let server = monitoredServers[defaultServerIndex];
 
 		// Find the server to rename

--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -52,12 +52,19 @@ module.exports = {
 			return;
 		}
 
-		// Rename the server
+        // Rename the server category
+		try {
+			await interaction.guild.channels.cache.get(server.categoryId)
+			.setName(interaction.options.getString('nickname'));
+		}
+		catch(rateLimit) {
+			await sendMessage.newBasicMessage(interaction, 'The rate limit has been reached, please try renaming this server in a few minutes!');
+			return;
+		}
+
+		// Change the server nickname in the database
         server.nickname = interaction.options.getString('nickname');
         await serverDB.set(interaction.guildId, monitoredServers);
-
-        // Rename the server category
-        await interaction.guild.channels.cache.get(server.categoryId).setName(interaction.options.getString('nickname'));
 
 		await sendMessage.newBasicMessage(interaction, 'The server has successfully been renamed.');
 	}

--- a/commands/status.js
+++ b/commands/status.js
@@ -12,8 +12,8 @@ module.exports = {
 		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
 
 		// Find the default server
-		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default);
-		let serverIp = monitoredServers[defaultServerIndex].ip;
+		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default) || 0;
+		let serverIp = monitoredServers[defaultServerIndex].ip || null;
 
 		if(interaction.options.getString('server')) {
 			serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));

--- a/commands/unmonitor.js
+++ b/commands/unmonitor.js
@@ -38,7 +38,7 @@ module.exports = {
 		}
 
 		// Find the default server
-		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default);
+		let defaultServerIndex = await monitoredServers.findIndex((server) => server.default) || 0;
 		let server = monitoredServers[defaultServerIndex];
 
 		// Find the server to unmonitor
@@ -51,6 +51,12 @@ module.exports = {
 		// Check if the server is being monitored
 		if (!server) {
 			await sendMessage.newBasicMessage(interaction, 'The server you have specified was not already being monitored!')
+			return;
+		}
+
+		// Check if the server being unmonitored is the default server for all commands
+		if (server.default && monitoredServers.length > 1) {
+			await sendMessage.newBasicMessage(interaction, 'You have more than one server monitored, and the server you are trying to unmonitor is the default server. Please set a new default!');
 			return;
 		}
 		

--- a/events/channelUpdate.js
+++ b/events/channelUpdate.js
@@ -1,0 +1,23 @@
+const Discord = require('discord.js');
+
+module.exports = {
+	name: 'channelUpdate',
+	once: false,
+	async execute(_, newChannel, client) {
+        // Check if the bot has the manage roles permission
+		if (!newChannel.guild.roles.botRoleFor(client.user).permissions.has(Discord.PermissionsBitField.Flags.ManageRoles)) return;
+
+        // Check if the updated channel is in the list of monitored channels
+        const monitoredServers = (await serverDB.get(newChannel.guildId)) || [];
+		let serverIndex = await monitoredServers.findIndex((server) => newChannel.id == server.categoryId);
+        if (serverIndex == -1) return;
+
+        // Check if the channel name is the same as the nickname listed in the database
+        let server = monitoredServers[serverIndex];
+        if (newChannel.name == server.nickname || newChannel.name == server.ip) return;
+        
+        // Set the nickname listed in the database to the channel name
+        server.nickname = newChannel.name;
+        await serverDB.set(newChannel.guildId, monitoredServers);
+	}
+};

--- a/functions/removeServer.js
+++ b/functions/removeServer.js
@@ -9,7 +9,7 @@ module.exports = {
 			];
 			channels.forEach((channel) => channel.delete());
 		} catch (error) {
-			console.log('Error deleting channel');
+			console.log(error);
 		}
 
 		// Remove server from database

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ const express = require('express');
 const fs = require('fs');
 const Keyv = require('keyv');
 
-client = new Client({ intents: [GatewayIntentBits.Guilds] });
+client = new Client({
+	intents: [GatewayIntentBits.Guilds],
+	rest: {rejectOnRateLimit: ['/channels']}
+});
 embedColor = '#7289DA';
 
 // Server


### PR DESCRIPTION
-Fixed a bug where unmonitoring the default server would result in no default servers for the guild, breaking most commands
-Fixed a bug where renaming a channel with the /nickname too many times would trigger rate limiting without any error handling
-Manually renaming a channel now updates the nickname in the database