### PR TITLE
fixed updating nickname in db twice

### DIFF
--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -49,12 +49,6 @@ async function execute(interaction) {
 		return;
 	}
 
-	// Change the server nickname in the database
-	let monitoredServers = await getKey(interaction.guildId);
-	const serverIndex = await findServerIndex(server, interaction.guildId);
-	monitoredServers[serverIndex].nickname = interaction.options.getString('nickname');
-	await setKey(interaction.guildId, monitoredServers);
-
 	console.log(`${server.ip} was given a nickname in guild ${interaction.guildId}`);
 
 	await sendMessage(interaction, 'The server has successfully been renamed.');


### PR DESCRIPTION
false error would be thrown for nickname command, as it would try to rename server in db twice